### PR TITLE
Fixed an issue where when improting an ESPD Request as CA: Compulsory value was wrong for mandatory EG Criteria

### DIFF
--- a/builder/src/main/java/eu/esens/espdvcd/retriever/criteria/CriteriaExtractorImpl.java
+++ b/builder/src/main/java/eu/esens/espdvcd/retriever/criteria/CriteriaExtractorImpl.java
@@ -149,7 +149,10 @@ public class CriteriaExtractorImpl implements CriteriaExtractor {
     public List<SelectableCriterion> getFullList(List<SelectableCriterion> initialList, boolean addAsSelected) {
         initCriterionList();
         Set<SelectableCriterion> initialSet = new LinkedHashSet<>();
-        initialList.forEach(sc -> sc.setSelected(addAsSelected));
+        initialList.forEach(sc -> {
+            sc.setSelected(addAsSelected);
+            sc.setCompulsory(CriteriaConfig.getInstance().isCompulsory(operator, sc.getID()));
+        });
         criterionList.forEach(sc -> sc.setSelected(false));
         initialSet.addAll(initialList);
         initialSet.addAll(criterionList);

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/endpoint/ImportESPDEndpoint.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/endpoint/ImportESPDEndpoint.java
@@ -16,6 +16,7 @@
 package eu.esens.espdvcd.designer.endpoint;
 
 import eu.esens.espdvcd.builder.exception.BuilderException;
+import eu.esens.espdvcd.codelist.enums.internal.ContractingOperatorEnum;
 import eu.esens.espdvcd.designer.exception.ValidationException;
 import eu.esens.espdvcd.designer.service.ImportESPDService;
 import eu.esens.espdvcd.designer.util.AppConfig;
@@ -42,6 +43,7 @@ import java.util.Objects;
 
 public class ImportESPDEndpoint extends Endpoint {
     private final ImportESPDService service;
+    private static final String CONTRACTING_OPERATOR_PARAM = "contractingOperator";
 
     public ImportESPDEndpoint(ImportESPDService service) {
         this.service = service;
@@ -57,6 +59,14 @@ public class ImportESPDEndpoint extends Endpoint {
             }), JsonUtil.json());
 
             spark.post("", (rq, rsp) -> {
+                ContractingOperatorEnum contractingOperatorEnum;
+                try {
+                    contractingOperatorEnum = ContractingOperatorEnum.valueOf(
+                            rq.queryParams(CONTRACTING_OPERATOR_PARAM));
+                } catch (IllegalArgumentException | NullPointerException e) {
+                    LOGGER.warning("Failed to extract the contracting operator. Falling back to default, which is CONTRACTING_ENTITY");
+                    contractingOperatorEnum = ContractingOperatorEnum.CONTRACTING_ENTITY;
+                }
                 rsp.header("Content-Type", "application/json");
                 if (Objects.nonNull(rq.contentType())) {
                     String LOGGER_DOCUMENT_ERROR = "Error occurred in ESPDEndpoint while converting an XML response to an object. ";
@@ -94,7 +104,7 @@ public class ImportESPDEndpoint extends Endpoint {
                             }
                             writeDumpedFile(tempFile);
                             try {
-                                return service.importESPDFile(tempFile);
+                                return service.importESPDFile(tempFile, contractingOperatorEnum);
                             } catch (RetrieverException | BuilderException | NullPointerException e) {
                                 LOGGER.severe(LOGGER_DOCUMENT_ERROR + e.getMessage());
                                 rsp.status(406);
@@ -124,7 +134,7 @@ public class ImportESPDEndpoint extends Endpoint {
 
                             writeDumpedFile(espdFile);
 
-                            return service.importESPDFile(espdFile);
+                            return service.importESPDFile(espdFile, contractingOperatorEnum);
                         } catch (RetrieverException | BuilderException | UnmarshalException e) {
                             LOGGER.severe(LOGGER_DOCUMENT_ERROR + e.getMessage());
                             rsp.status(406);

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/CriteriaService.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/CriteriaService.java
@@ -40,7 +40,7 @@ public interface CriteriaService {
     }
 
     default  List<SelectableCriterion> getUnselectedCriteria(List<SelectableCriterion> initialList) throws RetrieverException {
-        return getUnselectedCriteria(initialList, ContractingOperatorEnum.CONTRACTING_ENTITY);
+        return getUnselectedCriteria(initialList, ContractingOperatorEnum.CONTRACTING_AUTHORITY);
     }
 
     default List<SelectableCriterion> getCriteria() throws RetrieverException{

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/CriteriaService.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/CriteriaService.java
@@ -40,7 +40,7 @@ public interface CriteriaService {
     }
 
     default  List<SelectableCriterion> getUnselectedCriteria(List<SelectableCriterion> initialList) throws RetrieverException {
-        return getUnselectedCriteria(initialList, ContractingOperatorEnum.CONTRACTING_AUTHORITY);
+        return getUnselectedCriteria(initialList, ContractingOperatorEnum.CONTRACTING_ENTITY);
     }
 
     default List<SelectableCriterion> getCriteria() throws RetrieverException{

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDRequestService.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDRequestService.java
@@ -19,6 +19,7 @@ import eu.esens.espdvcd.builder.BuilderFactory;
 import eu.esens.espdvcd.builder.exception.BuilderException;
 import eu.esens.espdvcd.builder.util.ArtefactUtils;
 import eu.esens.espdvcd.codelist.enums.QualificationApplicationTypeEnum;
+import eu.esens.espdvcd.codelist.enums.internal.ContractingOperatorEnum;
 import eu.esens.espdvcd.designer.exception.ValidationException;
 import eu.esens.espdvcd.designer.util.CriteriaUtil;
 import eu.esens.espdvcd.model.ESPDRequest;
@@ -44,7 +45,7 @@ public enum ImportESPDRequestService implements ImportESPDService<ESPDRequest> {
     }
 
     @Override
-    public ESPDRequest importESPDFile(File XML) throws RetrieverException, BuilderException, JAXBException, SAXException, ValidationException, IOException {
+    public ESPDRequest importESPDFile(File XML, ContractingOperatorEnum contractingOperatorEnum) throws RetrieverException, BuilderException, JAXBException, SAXException, ValidationException, IOException {
         EDMVersion artefactVersion = ArtefactUtils.findEDMVersion(new FileInputStream(XML));
         QualificationApplicationTypeEnum qualificationApplicationType = ArtefactUtils.findQualificationApplicationType(XML);
 
@@ -76,7 +77,7 @@ public enum ImportESPDRequestService implements ImportESPDService<ESPDRequest> {
                 break;
         }
         Objects.requireNonNull(request);
-        request.setCriterionList(criteriaService.getUnselectedCriteria(request.getFullCriterionList()));
+        request.setCriterionList(criteriaService.getUnselectedCriteria(request.getFullCriterionList(), contractingOperatorEnum));
         CriteriaUtil.generateUUIDs(request.getFullCriterionList());
         is.close();
         return request;

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDResponseService.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDResponseService.java
@@ -19,10 +19,12 @@ import eu.esens.espdvcd.builder.BuilderFactory;
 import eu.esens.espdvcd.builder.exception.BuilderException;
 import eu.esens.espdvcd.builder.util.ArtefactUtils;
 import eu.esens.espdvcd.codelist.enums.QualificationApplicationTypeEnum;
+import eu.esens.espdvcd.codelist.enums.internal.ContractingOperatorEnum;
 import eu.esens.espdvcd.designer.exception.ValidationException;
 import eu.esens.espdvcd.designer.util.CriteriaUtil;
 import eu.esens.espdvcd.model.ESPDResponse;
 import eu.esens.espdvcd.schema.enums.EDMVersion;
+import jakarta.validation.constraints.Null;
 import org.xml.sax.SAXException;
 
 import javax.xml.bind.JAXBException;
@@ -42,8 +44,19 @@ public enum ImportESPDResponseService implements ImportESPDService<ESPDResponse>
         return INSTANCE;
     }
 
+    /**
+     *
+     * @param XML
+     * @param contractingOperatorEnum Currently not used in Response, therefore it could be null
+     * @return
+     * @throws BuilderException
+     * @throws JAXBException
+     * @throws SAXException
+     * @throws ValidationException
+     * @throws IOException
+     */
     @Override
-    public ESPDResponse importESPDFile(File XML) throws BuilderException, JAXBException, SAXException, ValidationException, IOException {
+    public ESPDResponse importESPDFile(File XML, @Null ContractingOperatorEnum contractingOperatorEnum) throws BuilderException, JAXBException, SAXException, ValidationException, IOException {
         EDMVersion artefactVersion = ArtefactUtils.findEDMVersion(XML);
         QualificationApplicationTypeEnum qualificationApplicationType = ArtefactUtils.findQualificationApplicationType(XML);
 
@@ -76,4 +89,5 @@ public enum ImportESPDResponseService implements ImportESPDService<ESPDResponse>
         is.close();
         return response;
     }
+
 }

--- a/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDService.java
+++ b/designer/designer-backend/src/main/java/eu.esens.espdvcd.designer/service/ImportESPDService.java
@@ -16,6 +16,7 @@
 package eu.esens.espdvcd.designer.service;
 
 import eu.esens.espdvcd.builder.exception.BuilderException;
+import eu.esens.espdvcd.codelist.enums.internal.ContractingOperatorEnum;
 import eu.esens.espdvcd.designer.exception.ValidationException;
 import eu.esens.espdvcd.model.ESPDRequest;
 import eu.esens.espdvcd.retriever.exception.RetrieverException;
@@ -27,5 +28,5 @@ import java.io.File;
 import java.io.IOException;
 
 public interface ImportESPDService<T extends ESPDRequest> {
-    T importESPDFile(@NotNull File XML) throws RetrieverException, BuilderException, JAXBException, SAXException, ValidationException, IOException;
+    T importESPDFile(@NotNull File XML, ContractingOperatorEnum contractingOperatorEnum) throws RetrieverException, BuilderException, JAXBException, SAXException, ValidationException, IOException;
 }

--- a/designer/designer-backend/src/test/java/eu/esens/espdvcd/designer/service/ImportESPDServiceTest.java
+++ b/designer/designer-backend/src/test/java/eu/esens/espdvcd/designer/service/ImportESPDServiceTest.java
@@ -17,6 +17,7 @@ package eu.esens.espdvcd.designer.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import eu.esens.espdvcd.codelist.enums.internal.ContractingOperatorEnum;
 import eu.esens.espdvcd.model.ESPDRequest;
 import eu.esens.espdvcd.model.ESPDResponse;
 import eu.esens.espdvcd.model.SelectableCriterion;
@@ -68,7 +69,7 @@ public class ImportESPDServiceTest {
     public void testQuantityIntegerImport() throws Exception {
         ImportESPDService service = ImportESPDResponseService.getInstance();
         Assert.assertNotNull(espdResponse);
-        ESPDResponse theResponse = (ESPDResponse) service.importESPDFile(espdResponse);
+        ESPDResponse theResponse = (ESPDResponse) service.importESPDFile(espdResponse, ContractingOperatorEnum.CONTRACTING_AUTHORITY);
 
         List<Requirement> requirementList = theResponse.getFullCriterionList().stream()
                 .filter(cr -> cr.getID().equals("b16cb9fc-6cb7-4585-9302-9533b415cf48"))
@@ -101,13 +102,13 @@ public class ImportESPDServiceTest {
 
     @Test
     public void responseJSONFromResponseTest() throws Exception {
-        ESPDResponse response = (ESPDResponse) importESPDService.importESPDFile(espdResponseFile);
+        ESPDResponse response = (ESPDResponse) importESPDService.importESPDFile(espdResponseFile, ContractingOperatorEnum.CONTRACTING_AUTHORITY);
         Assert.assertNotNull(response);
     }
 
     @Test
     public void requestSelfContainedImport() throws Exception {
-        ESPDRequest request = ImportESPDRequestService.getInstance().importESPDFile(new File(this.getClass().getClassLoader().getResource("sfc-210-da-req.xml").toURI()));
+        ESPDRequest request = ImportESPDRequestService.getInstance().importESPDFile(new File(this.getClass().getClassLoader().getResource("sfc-210-da-req.xml").toURI()), ContractingOperatorEnum.CONTRACTING_AUTHORITY);
         System.out.println(writer.writeValueAsString(request));
     }
 }


### PR DESCRIPTION
This merge will fix the issue where the compulsory EG Criteria weren't returned as compulsory during the Import ESPD Request flow. This will affect only the CONTRACTING_AUTHORITY flow. In the CONTRACTING_ENTITY flow, all criteria can be unselected as before.